### PR TITLE
Possible fix

### DIFF
--- a/Assets/Synonyms.cs
+++ b/Assets/Synonyms.cs
@@ -96,7 +96,6 @@ public class Synonyms : MonoBehaviour
         }
         if (unicorn < 3 || unicorn > 97)
         {
-            screen = 3;
             match = false;
         }
 


### PR DESCRIPTION
"screen" is already randomized in line 65, so there's no need to change it anymore here. In fact, it is incorrect to change it here, as it is a local variable and the NumberText was already set before this variable modification, meaning not only it won't be reflected in Start(), it also has no impact on NumberText.